### PR TITLE
Allow overrides of bundled files

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ define(["package1", "package2", "package3" /*and so on*/])
 #### Package Main File
 The path to the main javascript file is identified by the 'main' property in each packages bower.json, if this is not present then index.js will be assumed.
 
-
 ### Options
 
 #### options.baseUrl
@@ -74,6 +73,21 @@ Possible values: `'require'` or `'define'`
 
 The requirejs-bundle task will emit either an AMD require statement or an AMD define.
 The default is an AMD require.
+
+#### options.appOverrideUrl
+Type: `String`
+Default value: `undefined`
+
+Directory to look for overrides in. Files found in this directory will superceed the files found elsewhere.
+Requires `options.requireOverrideBaseUrl` to be set.
+
+
+#### options.requireOverrideBaseUrl
+Type: `String`
+Default value: `undefined`
+
+The require path to prepend to each overridden file.
+Requires `options.appOverrideUrl` to be set.
 
 ```js
 define("module-name", ["package1", "package2", "package3" /*and so on*/])

--- a/tasks/AMDBundleProcesses.js
+++ b/tasks/AMDBundleProcesses.js
@@ -30,13 +30,20 @@ AMDBundleProcesses.prototype.expandFullPackagePath = function (baseUrl) {
     var grunt = this.grunt,
         options = this.options;
 
-    return function (target) {    
+    return function (target) {
         var expandedPackagePaths = target.packageNames.map(function (packageName) {
                 var manifestFilePath = path.join(target.path, packageName, options.manifestFile),
                     mainFile = getJavascriptMainFile(grunt.file.readJSON(manifestFilePath)),
                     packageUrl = new Url(target.path, packageName, mainFile);
 
-                return packageUrl.makeRelative(baseUrl).href;
+                if (options.appOverrideUrl
+                        && options.requireOverrideBaseUrl
+                        && grunt.file.exists(new Url(options.appOverrideUrl, packageName, mainFile).href+'.js')) {
+                    return new Url(options.requireOverrideBaseUrl, packageName, mainFile).href;
+                } else {
+                    return packageUrl.makeRelative(baseUrl).href;
+                }
+
             });
 
         return {


### PR DESCRIPTION
If files are found in an 'override' directory, use them instead of the ones found in the src folder