### PR TITLE
Adds filter option

### DIFF
--- a/tasks/AMDBundleProcesses.js
+++ b/tasks/AMDBundleProcesses.js
@@ -21,6 +21,10 @@ AMDBundleProcesses.prototype.enumerateInstalledPackages = function(path) {
                                 cwd: path, 
                                 filter: 'isDirectory'
                             }, include)
+                            .filter(function(dir) {
+                                if(options.filter) return options.filter(dir)
+                                else return true;
+                            })
                             .filter(function hasManifest(dir) {
                                 return grunt.file.exists(path, dir, options.manifestFile)
                             }) || []

--- a/tasks/AMDBundleProcesses.js
+++ b/tasks/AMDBundleProcesses.js
@@ -12,13 +12,13 @@ AMDBundleProcesses.prototype.isDirectory = function (path) {
 AMDBundleProcesses.prototype.enumerateInstalledPackages = function(path) {
     var grunt = this.grunt,
         options = this.options;
-        
+
     var include = options.include || '*';
 
     return {
         path: path,
         packageNames: grunt.file.expand({
-                                cwd: path, 
+                                cwd: path,
                                 filter: 'isDirectory'
                             }, include)
                             .filter(function(dir) {
@@ -28,7 +28,7 @@ AMDBundleProcesses.prototype.enumerateInstalledPackages = function(path) {
                             .filter(function hasManifest(dir) {
                                 return grunt.file.exists(path, dir, options.manifestFile)
                             }) || []
-    };       
+    };
 };
 AMDBundleProcesses.prototype.expandFullPackagePath = function (baseUrl) {
     var grunt = this.grunt,


### PR DESCRIPTION
Hi Chris,

We need to be able to exclude certain plugins from the build process, so this is my attempt at doing it. It just adds a 'filter' attribute to the task options. 

Let me know if it can be done a better way :smile: 
